### PR TITLE
Fix: Preserve subscribers when editing notes, files, weblinks, and contacts

### DIFF
--- a/application/views/contact/edit_contact.php
+++ b/application/views/contact/edit_contact.php
@@ -399,7 +399,8 @@ $all_user_groups = PermissionGroups::instance()->getUserGroupsInfo();
 					if ((!$object->isNew() && $object->isUser()) || array_var($_GET, 'is_user')) {
 					} else {
 					?><input type="hidden" id="<?php echo $genid ?>subscribers_ids_hidden" value="<?php echo implode(',', $subscriber_ids) ?>" />
-					<?php } ?>
+					<input type="hidden" id="<?php echo $genid ?>original_subscribers" value="<?php echo implode(',', $subscriber_ids) ?>" />
+						<?php } ?>
 					<div id="<?php echo $genid ?>add_subscribers_content"><?php
 																			foreach ($subscriber_ids as $subid) {
 																				echo '<input type="hidden" name="subscribers[user_' . $subid . ']" value="1"/>';
@@ -527,4 +528,5 @@ $all_user_groups = PermissionGroups::instance()->getUserGroupsInfo();
 			</script>
 		</div>
 	</div>
+
 </form>

--- a/application/views/files/add_file.php
+++ b/application/views/files/add_file.php
@@ -339,6 +339,7 @@ Hook::fire('object_edit_categories', $object, $categories);
 					$subscriber_ids[] = logged_user()->getId();
 				}
 			?><input type="hidden" id="<?php echo $genid ?>subscribers_ids_hidden" value="<?php echo implode(',',$subscriber_ids)?>"/>
+			<input type="hidden" id="<?php echo $genid ?>original_subscribers" value="<?php echo implode(',',$subscriber_ids)?>"/>
 			<div id="<?php echo $genid ?>add_subscribers_content"><?php
 				foreach ($subscriber_ids as $subid) {
 					echo '<input type="hidden" name="subscribers[user_'.$subid.']" value="1"/>';
@@ -503,4 +504,5 @@ Hook::fire('object_edit_categories', $object, $categories);
         	$(".simplemodal-data .coInputHeader .coInputName").css('white-space', 'nowrap');
 
         }, 500);
+
 </script>

--- a/application/views/message/add_message.php
+++ b/application/views/message/add_message.php
@@ -196,6 +196,7 @@
 				}
 			?>
 			<input type="hidden" id="<?php echo $genid ?>subscribers_ids_hidden" value="<?php echo implode(',',$subscriber_ids)?>"/>
+			<input type="hidden" id="<?php echo $genid ?>original_subscribers" value="<?php echo implode(',',$subscriber_ids)?>"/>
 			<div id="<?php echo $genid ?>add_subscribers_content"><?php
 				foreach ($subscriber_ids as $subid) {
 					echo '<input type="hidden" name="subscribers[user_'.$subid.']" value="1"/>';
@@ -227,4 +228,5 @@
 $(function() {
 	$("#<?php echo $genid?>tabs").tabs();
 });
+
 </script>

--- a/application/views/webpage/add.php
+++ b/application/views/webpage/add.php
@@ -120,6 +120,7 @@
 				$subscriber_ids[] = logged_user()->getId();
 			}
 		?><input type="hidden" id="<?php echo $genid ?>subscribers_ids_hidden" value="<?php echo implode(',',$subscriber_ids)?>"/>
+		<input type="hidden" id="<?php echo $genid ?>original_subscribers" value="<?php echo implode(',',$subscriber_ids)?>"/>
 		<div id="<?php echo $genid ?>add_subscribers_content"><?php
 			foreach ($subscriber_ids as $subid) {
 				echo '<input type="hidden" name="subscribers[user_'.$subid.']" value="1"/>';
@@ -166,4 +167,5 @@
         	$(".simplemodal-data .coInputHeader .coInputName").css('white-space', 'nowrap');
         }, 500);
 	});
+
 </script>


### PR DESCRIPTION
## Summary
Fixes a critical bug where all subscribers were being removed when editing notes, files, weblinks, or contacts in Feng Office 3.11.8.0-RC4.

## Problem
When editing any of these object types, the subscriber form would show all existing subscribers as unchecked, causing them to be unsubscribed upon save. This triggered unwanted unsubscribe notification emails to all affected users.

Tasks were unaffected as they already had the proper implementation.

## Root Cause
The subscriber form component uses JavaScript to dynamically reload subscriber lists based on workspace/dimension changes. During AJAX reloads, the form needs the `original_subscribers` hidden field to preserve the initial subscriber state. This field was present in task forms but missing in note, file, weblink, and contact forms.

## Solution
Added the missing `original_subscribers` hidden input field to all affected form templates, matching the working implementation in task forms.

## Files Changed
- `application/views/message/add_message.php` - Notes
- `application/views/files/add_file.php` - Files  
- `application/views/webpage/add.php` - Weblinks
- `application/views/contact/edit_contact.php` - Contacts